### PR TITLE
Fix jslib-modify-jquery so that it doesn't run out of memory under a fast JS engine with limited memory

### DIFF
--- a/tests/jslib-modify-jquery.html
+++ b/tests/jslib-modify-jquery.html
@@ -12,7 +12,7 @@ var ret, tmp, div, a, dd;
 var html = document.body.innerHTML,
 	elem = document.createElement("div"),
 	elem2 = document.createElement("strong"),
-	elemStr = "<strong>some text</strong>";
+	elemStr = "<strike>some text</strike>";
 
 	prep(function(){
 		a = jQuery("a");
@@ -29,24 +29,44 @@ var html = document.body.innerHTML,
 	});
 	*/
 
+	var runs = 0;
 	test("jQuery - html()", function(){
 		dd.html( elemStr );
+		runs++;
+		if (runs % 1000 == 0)
+			jQuery('strike').remove();
 	});
 
+	runs = 0;
 	test("jQuery - before()", function(){
 		div.before( elemStr );
+		runs++;
+		if (runs % 1000 == 0)
+			jQuery('strike').remove();
 	});
 
+	runs = 0;
 	test("jQuery - after()", function(){
-		div.before( elemStr );
+		div.after( elemStr );
+		runs++;
+		if (runs % 1000 == 0)
+			jQuery('strike').remove();
 	});
 
+	runs = 0;
 	test("jQuery - prepend()", function(){
 		div.prepend( elemStr );
+		runs++;
+		if (runs % 1000 == 0)
+			jQuery('strike').remove();
 	});
 
+	runs = 0;
 	test("jQuery - append()", function(){
 		div.append( elemStr );
+		runs++;
+		if (runs % 1000 == 0)
+			jQuery('strike').remove();
 	});
 
 	/* // Need a good way to test


### PR DESCRIPTION
Remove nodes added by each test case every 1000 runs so that we don't end up with 1e+7 or 1e+8 nodes and use up the entire 4GB of RAM in Chromium.

To do this, changed the name of element we insert from strong to strike so that we can quickly enumerate all the elements to remove (strike doesn't appear elsewhere in the document).

Also, call after() in the test case labeled "jQuery - after()".
