### PR TITLE
Fix median calculation formula

### DIFF
--- a/dep/web/webrunner.js
+++ b/dep/web/webrunner.js
@@ -148,7 +148,7 @@
 		});
 
 		function compute(times, runs){
-			var results = {runs: runs}, num = times.length;
+			var results = {runs: runs}, num = times.length, middle = num/2;
 
 			times = times.sort(function(a,b){
 				return a - b;
@@ -171,8 +171,8 @@
 			
 			// Make Median
 			results.median = num % 2 == 0 ?
-				(times[Math.floor(num/2)] + times[Math.ceil(num/2)]) / 2 :
-				times[Math.round(num/2)];
+				(times[middle-1] + times[middle]) / 2 :
+				times[Math.floor(middle)];
 			
 			// Make Variance
 			results.variance = 0;


### PR DESCRIPTION
The median calculating formula seems to be broken.

For example the formula applied on array of [1,2,3,4] previously calculated 2 as the median. In usual cases, however, 2.5 would be the answer ( (2 + 3) / 2 ).

For odd length arrays the formula is obviously faulty. For [1,2,3,4,5] it would return 4, when 3 is the only correct answer.
